### PR TITLE
fix issue that prevented date from rendering

### DIFF
--- a/src/components/BlogPosts.js
+++ b/src/components/BlogPosts.js
@@ -28,7 +28,7 @@ const firstParagraph = (post) => {
 // A summary of the Blog Post
 const PostSummary = ({ post, id }) => {
   // Store and format the blog post's publication date
-  let postDate = Date(post.date)
+  let postDate = Date(post.node.data.date)
   postDate = postDate
     ? new Intl.DateTimeFormat('en-US', {
       month: 'short',


### PR DESCRIPTION
I was using this as a template and tutorial for integrating prismic with gatsby and I had to add this change to get the date's on the homepage to populate properly as they do on the [demo](https://gatsby-prismic-blog.netlify.app/).